### PR TITLE
Amend dependabot paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: ".github/workflows"
+    directory: "/"
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
tflint fails when dependabot creates a PR against a path other than /

Compare the following pull requests:
https://github.com/dms1981/terraform-dynamic-fw-policy/pull/8
https://github.com/dms1981/terraform-dynamic-fw-policy/pull/9

These both update the same file and are both created by dependabot, but one fails with tflint and the other succeeds.